### PR TITLE
Create 69900000.json

### DIFF
--- a/v1/69900000.json
+++ b/v1/69900000.json
@@ -1,0 +1,9 @@
+{
+  "cep": "69900-000",
+  "logradouro": "",
+  "complemento": "",
+  "bairro": "",
+  "localidade": "Rio Branco",
+  "uf": "AC",
+  "ibge": "1200401"
+}


### PR DESCRIPTION
consultando a faixa de CEP do Acre no site dos correios mostra como sendo válido o CEP 69900-000, porém ele não está relacionado a cidade de Rio Branco nos Correios, que inicia no 69900-001 como visto abaixo:

![image](https://user-images.githubusercontent.com/126887158/222749411-1040e945-b5c0-40cd-8303-3676a8ba0cea.png)

seria interessante ter este cep vinculado a Rio Branco - AC também, retornando apenas as informações de localidade, uf e código ibge