### PR TITLE
Cadastro do cep 18542470

### DIFF
--- a/v1/18542470.json
+++ b/v1/18542470.json
@@ -1,0 +1,9 @@
+{
+    "cep": "18542-470",
+    "logradouro": "Rua Daniel de Camargo Taborda",
+    "complemento": "de 176/177 a 588/589",
+    "bairro": "Parque Residencial Água Branca",
+    "localidade": "Porto Feliz",
+    "uf": "SP",
+    "ibge": "3540606"
+  }


### PR DESCRIPTION
Na consulta atual "https://opencep.com/v1/18542470" está retornando "404 not found" com o json abaixo

{
  "error": true
}

Acredito que adicionando o 18542470.json, deve resolver